### PR TITLE
Allow for asynchronous grabbing of event values before trigger is run

### DIFF
--- a/src/main/java/me/iblitzkriegi/vixio/events/base/BaseEvent.java
+++ b/src/main/java/me/iblitzkriegi/vixio/events/base/BaseEvent.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 public abstract class BaseEvent<D extends net.dv8tion.jda.core.events.Event> extends SelfRegisteringSkriptEvent {
 
@@ -27,7 +28,7 @@ public abstract class BaseEvent<D extends net.dv8tion.jda.core.events.Event> ext
      * The ending appended to patterns if no custom ending is specified
      */
     public static final String APPENDED_ENDING = "[seen by %-string%]";
-    private HashMap<Class<?>, Object> valueMap = new HashMap<>();
+    private Map<Class<?>, Object> valueMap = new HashMap<>();
     private String stringRepresentation;
     private Trigger trigger;
     private EventListener<D> listener;

--- a/src/main/java/me/iblitzkriegi/vixio/events/base/SimpleVixioEvent.java
+++ b/src/main/java/me/iblitzkriegi/vixio/events/base/SimpleVixioEvent.java
@@ -1,11 +1,12 @@
 package me.iblitzkriegi.vixio.events.base;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class SimpleVixioEvent<D extends net.dv8tion.jda.core.events.Event> extends SimpleBukkitEvent {
 
     private D JDAEvent;
-    private HashMap<Class<?>, Object> valueMap = new HashMap<>();
+    private Map<Class<?>, Object> valueMap = new HashMap<>();
 
     public D getJDAEvent() {
         return JDAEvent;
@@ -15,11 +16,11 @@ public class SimpleVixioEvent<D extends net.dv8tion.jda.core.events.Event> exten
         this.JDAEvent = JDAEvent;
     }
 
-    public HashMap<Class<?>, Object> getValueMap() {
+    public Map<Class<?>, Object> getValueMap() {
         return valueMap;
     }
 
-    public void setValueMap(HashMap<Class<?>, Object> valueMap) {
+    public void setValueMap(Map<Class<?>, Object> valueMap) {
         this.valueMap = valueMap;
     }
 

--- a/src/main/java/me/iblitzkriegi/vixio/events/base/SimpleVixioEvent.java
+++ b/src/main/java/me/iblitzkriegi/vixio/events/base/SimpleVixioEvent.java
@@ -1,8 +1,11 @@
 package me.iblitzkriegi.vixio.events.base;
 
+import java.util.HashMap;
+
 public class SimpleVixioEvent<D extends net.dv8tion.jda.core.events.Event> extends SimpleBukkitEvent {
 
     private D JDAEvent;
+    private HashMap<Class<?>, Object> valueMap = new HashMap<>();
 
     public D getJDAEvent() {
         return JDAEvent;
@@ -10,6 +13,18 @@ public class SimpleVixioEvent<D extends net.dv8tion.jda.core.events.Event> exten
 
     public void setJDAEvent(D JDAEvent) {
         this.JDAEvent = JDAEvent;
+    }
+
+    public HashMap<Class<?>, Object> getValueMap() {
+        return valueMap;
+    }
+
+    public void setValueMap(HashMap<Class<?>, Object> valueMap) {
+        this.valueMap = valueMap;
+    }
+
+    public <T> T getValue(Class<T> clazz) {
+        return (T) valueMap.get(clazz);
     }
 
 }

--- a/src/main/java/me/iblitzkriegi/vixio/util/Util.java
+++ b/src/main/java/me/iblitzkriegi/vixio/util/Util.java
@@ -226,7 +226,11 @@ public class Util {
     }
 
     public static void sync(Runnable runnable) {
-        Bukkit.getScheduler().scheduleSyncDelayedTask(Vixio.getInstance(), runnable, 0);
+        Bukkit.getScheduler().runTask(Vixio.getInstance(), runnable);
+    }
+
+    public static void async(Runnable runnable) {
+        Bukkit.getScheduler().runTaskAsynchronously(Vixio.getInstance(), runnable);
     }
 
 }

--- a/src/main/java/me/iblitzkriegi/vixio/util/VixioGetter.java
+++ b/src/main/java/me/iblitzkriegi/vixio/util/VixioGetter.java
@@ -1,0 +1,7 @@
+package me.iblitzkriegi.vixio.util;
+
+public interface VixioGetter<A, R> {
+
+    R get(A arg);
+
+}


### PR DESCRIPTION
Example grabber method in an event that extends BaseEvent:
```
    @Override
    @SuppressWarnings("unchecked")
    public Value[] getValues() {
        return new BaseEvent.Value[] {
                new Value(Message.class, e -> {
                    try {
                        return e.getChannel().getMessageById(e.getMessageId()).complete(true);
                    } catch (RateLimitedException e1) {
                        Vixio.getErrorHandler().warn("Vixio tried to get the message event value for the reaction add event but was rate limited");
                        return null;
                    }
                })
        };
    }
```
then, the event value registration itself:
```
        EventValues.registerEventValue(ReactionAddEvent.class, Message.class, new Getter<Message, ReactionAddEvent>() {
            @Override
            public Message get(ReactionAddEvent e) {
                return e.getValue(Message.class);
            }
        }, 0);
```
