### PR TITLE
Fix for HasPermission condition

### DIFF
--- a/src/main/java/me/iblitzkriegi/vixio/conditions/CondHasPermission.java
+++ b/src/main/java/me/iblitzkriegi/vixio/conditions/CondHasPermission.java
@@ -71,8 +71,8 @@ public class CondHasPermission extends Condition {
             if (guild == null) {
                 return false;
             }
-            Member guildMember = guild.getMember(user);
-            if (guildMember == null) {
+            member = guild.getMember(user);
+            if (member == null) {
                 return false;
             }
 


### PR DESCRIPTION
• Fixed the NullPointerException on HasPermissionCond due to the `guildMember` variable (which is never used).