### PR TITLE
Updated code due to deprecation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,9 @@
-group 'me.iblitzkriegi.vixio'
+import org.apache.tools.ant.filters.ReplaceTokens
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-        classpath 'de.undercouch:gradle-download-task:3.3.0'
-    }
-
+plugins {
+    id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id 'java'
 }
-
-apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'com.github.ben-manes.versions'
-apply plugin: 'de.undercouch.download'
-apply plugin: 'java'
 
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
@@ -69,53 +57,30 @@ repositories {
 dependencies {
 
     // Spigot API
-    shadow group: 'org.spigotmc', name: 'spigot-api', version: project.property('apiversion')
+    implementation 'org.spigotmc:spigot-api:1.13.2-R0.1-SNAPSHOT'
 
     // JDA
 
-    compile "net.dv8tion:JDA:4.1.0_88"
+    compile "net.dv8tion:JDA:4.2.0_168"
 
     // LavaPlayer
-    compile 'com.sedmelluq:lavaplayer:1.3.47'
-    compile 'club.minnced:opus-java-api:v1.0.1'
+    compile 'com.sedmelluq:lavaplayer:1.3.50'
+    compile 'club.minnced:opus-java-api:v1.0.5'
 
     // Skript API
-    shadow group: 'ch.njol', name: 'skript', version: project.property('skriptapiversion')
+    implementation 'com.github.SkriptLang:Skript:2.3.7'
+
     compile 'ch.qos.logback:logback-classic:1.2.3'
-    compile 'com.vdurmont:emoji-java:3.3.0'
+    compile 'com.vdurmont:emoji-java:5.1.1'
     compile group: 'org.json', name: 'json', version: '20180813'
 
 
 }
 
-jar.enabled = false
-assemble.dependsOn(shadowJar)
-
-def pluginDir = 'src/main/resources/plugin.yml'
-def tempDir = 'build/tmp/tempResources'
-
-
-processResources.doFirst {
-    copy {
-        from(pluginDir)
-        into(tempDir)
-    }
-    ant.replace(file: pluginDir, token: '@VERSION@', value: project.property('version'))
-}
-
-processResources.doLast {
-    copy {
-        from(tempDir + '/plugin.yml')
-        into(project.file(pluginDir).parent)
-    }
+processResources {
+    filter(ReplaceTokens, tokens: [version: version])
 }
 
 shadowJar {
-    classifier = ''
-
-    relocate 'org.apache.commons.lang3', project.group + ".org.apache.commons.lang3"
-    relocate 'org.apache.http', project.group + ".org.apache.http"
-    relocate 'org.apache.commons.io', project.group + ".org.apache.commons.io"
-    destinationDir = new File(project.property('destinationDir'))
-
+    configurations = [project.configurations.compile]
 }

--- a/src/main/java/me/iblitzkriegi/vixio/effects/EffLogin.java
+++ b/src/main/java/me/iblitzkriegi/vixio/effects/EffLogin.java
@@ -9,10 +9,8 @@ import me.iblitzkriegi.vixio.events.base.EventListener;
 import me.iblitzkriegi.vixio.util.MessageUpdater;
 import me.iblitzkriegi.vixio.util.skript.AsyncEffect;
 import me.iblitzkriegi.vixio.util.wrapper.Bot;
-import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
-import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 
@@ -52,11 +50,7 @@ public class EffLogin extends AsyncEffect {
 
         JDA api;
         try {
-            try {
-                api = new JDABuilder(AccountType.BOT).setToken(token).build().awaitReady();
-            } catch (AccountTypeException x) {
-                api = new JDABuilder(AccountType.CLIENT).setToken(token).build().awaitReady();
-            }
+            api = JDABuilder.createDefault(token).build().awaitReady();
         } catch (LoginException | InterruptedException e1) {
             Vixio.getErrorHandler().warn("Vixio tried to login but encountered \"" + e1.getMessage() + "\"");
             Vixio.getErrorHandler().warn("Maybe your token is wrong?");
@@ -83,6 +77,7 @@ public class EffLogin extends AsyncEffect {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public boolean init(Expression<?>[] expr, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
         token = (Expression<String>) expr[0];
         name = (Expression<String>) expr[1];

--- a/src/main/java/me/iblitzkriegi/vixio/events/guild/EvtBotGuildLeave.java
+++ b/src/main/java/me/iblitzkriegi/vixio/events/guild/EvtBotGuildLeave.java
@@ -7,9 +7,9 @@ import me.iblitzkriegi.vixio.events.base.SimpleVixioEvent;
 import me.iblitzkriegi.vixio.util.Util;
 import me.iblitzkriegi.vixio.util.wrapper.Bot;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 
-public class EvtBotGuildLeave extends BaseEvent<GuildLeaveEvent> {
+public class EvtBotGuildLeave extends BaseEvent<GuildMemberRemoveEvent> {
     static {
         BaseEvent.register("bot leave guild", EvtBotGuildLeave.class, BotLeaveGuild.class, "bot (leave|exit) guild")
                 .setName("Bot Leave Guild")
@@ -32,5 +32,5 @@ public class EvtBotGuildLeave extends BaseEvent<GuildLeaveEvent> {
 
     }
 
-    public class BotLeaveGuild extends SimpleVixioEvent<GuildLeaveEvent> {}
+    public class BotLeaveGuild extends SimpleVixioEvent<GuildMemberRemoveEvent> {}
 }

--- a/src/main/java/me/iblitzkriegi/vixio/events/member/EvtLeaveGuild.java
+++ b/src/main/java/me/iblitzkriegi/vixio/events/member/EvtLeaveGuild.java
@@ -9,9 +9,9 @@ import me.iblitzkriegi.vixio.util.wrapper.Bot;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberLeaveEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 
-public class EvtLeaveGuild extends BaseEvent<GuildMemberLeaveEvent> {
+public class EvtLeaveGuild extends BaseEvent<GuildMemberRemoveEvent> {
 
     static {
 
@@ -51,7 +51,7 @@ public class EvtLeaveGuild extends BaseEvent<GuildMemberLeaveEvent> {
 
     }
 
-    public class JoinGuildEvent extends SimpleVixioEvent<GuildMemberLeaveEvent> {
+    public class JoinGuildEvent extends SimpleVixioEvent<GuildMemberRemoveEvent> {
     }
 
 }

--- a/src/main/java/me/iblitzkriegi/vixio/expressions/channel/ExprChannelNamed.java
+++ b/src/main/java/me/iblitzkriegi/vixio/expressions/channel/ExprChannelNamed.java
@@ -91,7 +91,7 @@ public class ExprChannelNamed extends SimpleExpression<GuildChannel> {
         Set<JDA> jdaInstances = Vixio.getInstance().botHashMap.keySet();
         for (JDA jda : jdaInstances) {
             if (mark == 0) {
-                voiceChannels = jda.getVoiceChannelByName(name, false);
+                voiceChannels = jda.getVoiceChannelsByName(name, false);
                 textChannels = jda.getTextChannelsByName(name, false);
                 if (!(voiceChannels.isEmpty()) || (!(textChannels.isEmpty()))) {
                     if (singular) {
@@ -110,7 +110,7 @@ public class ExprChannelNamed extends SimpleExpression<GuildChannel> {
                     return channels.toArray(new GuildChannel[size]);
                 }
             } else if (mark == 1) {
-                voiceChannels = jda.getVoiceChannelByName(name, false);
+                voiceChannels = jda.getVoiceChannelsByName(name, false);
                 if (!voiceChannels.isEmpty()) {
                     return singular ? new VoiceChannel[]{voiceChannels.get(0)} : voiceChannels.toArray(new VoiceChannel[voiceChannels.size()]);
                 }


### PR DESCRIPTION
This pull request includes:

## Updates

 - JDA ``4.2.0_168``
 - opus-java ``1.0.5``
 - lavaplayer ``1.3.50``
 - emoji-java ``5.1.1``

## JDA changes

 - ``net.dv8tion.jda.api.events.guild.GuildLeaveEvent`` and ``net.dv8tion.jda.api.events.guild.member.GuildMemberLeaveEvent`` deprecated, changed to ``net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent``
 - ``JDA#getVoiceChannelByName`` deprecated, changed to ``JDA#getVoiceChannelsByName``
 - ``new JDABuilder(AccountType.BOT).setToken(token)`` deprecated, change to ``JDABuilder.createDefault(token)``
 - ``AccountType.CLIENT`` deprecated, removed